### PR TITLE
Add support for multi-file import

### DIFF
--- a/io_pcd/__init__.py
+++ b/io_pcd/__init__.py
@@ -18,10 +18,11 @@
 
 # <pep8-80 compliant>
 
-from bpy.props import StringProperty
+from bpy.props import StringProperty, CollectionProperty
 from bpy_extras.io_utils import ImportHelper, ExportHelper
 from bpy.types import Operator
 import bpy
+import os
 
 bl_info = {
     "author": "Mark Hedley Jones",
@@ -52,6 +53,14 @@ class ImportPCD(Operator, ImportHelper):
 
     filename_ext = ".pcd"
 
+    files: CollectionProperty(
+        name="File Path",
+        description="File path used for importing the PCD file",
+        type=bpy.types.OperatorFileListElement,
+    )
+
+    directory: StringProperty()
+
     filter_glob: StringProperty(default="*.pcd", options={"HIDDEN"})
 
     @classmethod
@@ -61,7 +70,20 @@ class ImportPCD(Operator, ImportHelper):
     def execute(self, context):
         from . import import_pcd
 
-        return import_pcd.import_pcd(context, self.filepath)
+        paths = [
+            os.path.join(self.directory, name.name)
+            for name in self.files
+        ]
+
+        if not paths:
+            paths.append(self.filepath)
+
+        for path in paths:
+            import_pcd.import_pcd(context, path)
+
+        context.window.cursor_set('DEFAULT')
+
+        return {'FINISHED'}
 
 
 class ExportPCD(Operator, ExportHelper):

--- a/io_pcd/__init__.py
+++ b/io_pcd/__init__.py
@@ -32,7 +32,7 @@ bl_info = {
     "doc_url": "",
     "location": "File > Import/Export > PCD (.pcd)",
     "name": "Point Cloud Format (.pcd)",
-    "version": (1, 4, 0),
+    "version": (1, 5, 0),
     "warning": "",
 }
 


### PR DESCRIPTION
This PR enables multi-file import for PCD files.
I have edited the script with reference to the PLY file import script from:
https://github.com/blender/blender-addons/blob/016430de4b06714c006bb6de2ae3a28e05a86169/io_mesh_ply/__init__.py#L47-L84