### PR TITLE
Fix reading non-unix line endings

### DIFF
--- a/io_pcd/__init__.py
+++ b/io_pcd/__init__.py
@@ -70,10 +70,7 @@ class ImportPCD(Operator, ImportHelper):
     def execute(self, context):
         from . import import_pcd
 
-        paths = [
-            os.path.join(self.directory, name.name)
-            for name in self.files
-        ]
+        paths = [os.path.join(self.directory, name.name) for name in self.files]
 
         if not paths:
             paths.append(self.filepath)
@@ -81,9 +78,9 @@ class ImportPCD(Operator, ImportHelper):
         for path in paths:
             import_pcd.import_pcd(context, path)
 
-        context.window.cursor_set('DEFAULT')
+        context.window.cursor_set("DEFAULT")
 
-        return {'FINISHED'}
+        return {"FINISHED"}
 
 
 class ExportPCD(Operator, ExportHelper):

--- a/io_pcd/__init__.py
+++ b/io_pcd/__init__.py
@@ -32,7 +32,7 @@ bl_info = {
     "doc_url": "",
     "location": "File > Import/Export > PCD (.pcd)",
     "name": "Point Cloud Format (.pcd)",
-    "version": (1, 5, 0),
+    "version": (1, 5, 1),
     "warning": "",
 }
 

--- a/io_pcd/import_pcd.py
+++ b/io_pcd/import_pcd.py
@@ -76,16 +76,19 @@ def validated_header(header):
     return header
 
 
-def read_header(file_descriptor):
+def read_header(binary_file):
     def first(arr):
         return arr[0], arr[1:]
 
-    def front(arr):
-        return arr[:-1], arr[-1]
+    def convert_text(binary_line):
+        text_line = binary_line.decode("utf-8")
+        # Clean line-endings from binary data
+        clean_line_ending = text_line.rstrip("\n\r")
+        return clean_line_ending.rstrip()
 
-    for line in file_descriptor:
-        row, _ = front(line.decode("utf-8"))
-        head, tail = first(row.split(" "))
+    for binary_line in binary_file:
+        line = convert_text(binary_line)
+        head, tail = first(line.split(" "))
         if head in header:
             header[head] = " ".join(tail)
         if head == "DATA":


### PR DESCRIPTION
This pull-request closes #13 
It modifies the way line-endings are removed when reading the file (which is done in binary mode) so as to support windows and other systems that include the "/r" symbol.