### PR TITLE
Update import_pcd.py

### DIFF
--- a/io_pcd/import_pcd.py
+++ b/io_pcd/import_pcd.py
@@ -22,6 +22,7 @@
 
 import enum
 import os
+import math
 import struct
 import sys
 import time
@@ -100,13 +101,16 @@ def get_struct_format_chars(header):
     """Convert the field types/sizes into format specifiers for the
     struct package"""
     struct_formats = {
+        # Integer: signed-char, signed-short, signed-long, signed-long long
         "I": ["b", "h", "l", "q"],
+        # Unsigned-Integer: unsigned-char, unsigned-short, unsigned-long, unsigned-long long
         "U": ["B", "H", "I", "Q"],
+        # float: pad byte, float 16, float 32, double (float 64)
         "F": ["x", "e", "f", "d"],
     }
     struct_formatting = []
     for field_type, field_size in zip(header["TYPE"], header["SIZE"]):
-        field_size_index = int(field_size**0.5)
+        field_size_index = int(math.log2(field_size))
         struct_formatting.append(struct_formats[field_type][field_size_index])
     # Check that a 1 byte float hasn't been specified!
     assert "x" not in struct_formatting


### PR DESCRIPTION
Bugfix for fixes #19

There was an issue with your implementation. Taking the square root was the wrong mathematical approach, it gave incorrect results.

The header in question was this:
```python
{'VERSION': '0.7', 'FIELDS': ['x', 'y', 'z', 'intensity', 't', 'time', 'timestamp'], 'SIZE': [4, 4, 4, 4, 4, 4, 8], 'TYPE': ['F', 'F', 'F', 'F', 'U', 'F', 'F'], 'COUNT': [1, 1, 1, 1, 1, 1, 1], 'WIDTH': 5620, 'HEIGHT': 1, 'VIEWPOINT': [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0], 'POINTS': 5620, 'DATA': 'binary'}
```
The error is `int(field_size**0.5)`

Your function does the following:
- 8
- 8**0.5 = 2.82
- int(2.82) = 2
- got `f` instead of `d` from the `struct formats` variable.

- The solution would have been correct in the given instance, had you taken `math.ceil(field_size**0.5)` Anything larger than or equal to `32` wouldn't work. `32 ** 0.5 = 5.65`, with `math.ceil`, you're at `6`, and the correct value would be `5`
- Since we're dealing in powers of 2, it only makes sense to take the `math.log2`
- While it returns a float, it is `log2(1) = 0.0`, `log2(2) = 1.0`, `log2(4) = 2.0` and `log2(8) = 3.0` which is exactly what we want.